### PR TITLE
Update to 2.9.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: wordpress-desktop
-version: 2.7.0
+version: 2.9.0
 summary: WordPress.com Desktop client
 description: |
  A desktop app that gives WordPress a permanent home in your dock.


### PR DESCRIPTION
https://github.com/Automattic/wp-desktop/releases/tag/v2.9.0

Could use https://github.com/Automattic/wp-desktop/releases/download/v2.9.0/wordpress-com-2.9.0.deb to get the deb and force a re-snap (the current Deb link is a generic one).