### PR TITLE
Migrate to GNOME 3.28 platform snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,20 +54,12 @@ apps:
     extensions: [gnome-3-28]
     command: opt/WordPress.com/wpcom
     desktop: usr/share/applications/wpcom.desktop
-    # Correct the TMPDIR path for Chromium Framework/Electron to ensure
-    # libappindicator has readable resources.
     environment:
       TMPDIR: $XDG_RUNTIME_DIR
     plugs:
       - browser-support
-      - desktop
-      - desktop-legacy
-      - gsettings
       - home
-      - mount-observe
       - network
       - opengl
       - pulseaudio
       - unity7
-      - wayland
-      - x11

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,7 @@ parts:
       echo "Version: $VERSION"
       snapcraftctl set-version "$VERSION"
       snapcraftctl build
+      sed -i 's|Icon=wpcom|Icon=/usr/share/icons/hicolor/256x256/apps/wpcom\.png|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/wpcom.desktop
     build-packages:
       - curl
     stage-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,12 +20,6 @@ confinement: strict
 architectures:
   - build-on: amd64
 
-plugs:
-  gnome-3-28-1804:
-    interface: content
-    target: $SNAP/gnome-platform
-    default-provider: gnome-3-28-1804
-
 parts:
   wordpress-desktop:
     plugin: dump
@@ -41,14 +35,10 @@ parts:
     build-packages:
       - curl
     stage-packages:
-      - libasound2
-      - libgconf-2-4
-      - libnotify4
       - libnspr4
       - libnss3
-      - libpulse0
+      - libxkbfile1
       - libxss1
-      - libxtst6
   cleanup:
     after: [ wordpress-desktop ]
     plugin: nil


### PR DESCRIPTION
The pull request completes the migration to the GNOME 3.28 platform snap, fixes the icon path and reduces the size of the snap by ~4MB